### PR TITLE
Enforcing all IngredientController endpoints return reactive types to…

### DIFF
--- a/ch12_13/tacocloud-cassandra/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
+++ b/ch12_13/tacocloud-cassandra/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
@@ -44,11 +44,11 @@ public class IngredientController {
   }
 
   @PutMapping("/{id}")
-  public void updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
+  public Mono<Ingredient> updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
     if (!ingredient.getId().equals(id)) {
       throw new IllegalStateException("Given ingredient's ID doesn't match the ID in the path.");
     }
-    repo.save(ingredient);
+    return repo.save(ingredient);
   }
 
   @PostMapping
@@ -63,8 +63,8 @@ public class IngredientController {
   }
 
   @DeleteMapping("/{id}")
-  public void deleteIngredient(@PathVariable String id) {
-    repo.deleteById(id);
+  public Mono<Void> deleteIngredient(@PathVariable String id) {
+    return repo.deleteById(id);
   }
 
 }

--- a/ch12_13/tacocloud-mongodb/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
+++ b/ch12_13/tacocloud-mongodb/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
@@ -44,11 +44,11 @@ public class IngredientController {
   }
 
   @PutMapping("/{id}")
-  public void updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
+  public Mono<Ingredient> updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
     if (!ingredient.getId().equals(id)) {
       throw new IllegalStateException("Given ingredient's ID doesn't match the ID in the path.");
     }
-    repo.save(ingredient);
+    return repo.save(ingredient);
   }
 
   @PostMapping
@@ -63,8 +63,8 @@ public class IngredientController {
   }
 
   @DeleteMapping("/{id}")
-  public void deleteIngredient(@PathVariable String id) {
-    repo.deleteById(id);
+  public Mono<Void> deleteIngredient(@PathVariable String id) {
+    return repo.deleteById(id);
   }
 
 }

--- a/ch15_16/tacocloud/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
+++ b/ch15_16/tacocloud/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
@@ -44,11 +44,11 @@ public class IngredientController {
   }
 
   @PutMapping("/{id}")
-  public void updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
+  public Mono<Ingredient> updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
     if (!ingredient.getId().equals(id)) {
       throw new IllegalStateException("Given ingredient's ID doesn't match the ID in the path.");
     }
-    repo.save(ingredient);
+    return repo.save(ingredient);
   }
 
   @PostMapping
@@ -63,8 +63,8 @@ public class IngredientController {
   }
 
   @DeleteMapping("/{id}")
-  public void deleteIngredient(@PathVariable String id) {
-    repo.deleteById(id);
+  public Mono<Void> deleteIngredient(@PathVariable String id) {
+    return repo.deleteById(id);
   }
 
 }

--- a/ch17/tacocloud/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
+++ b/ch17/tacocloud/tacocloud-api/src/main/java/tacos/web/api/IngredientController.java
@@ -44,11 +44,11 @@ public class IngredientController {
   }
 
   @PutMapping("/{id}")
-  public void updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
+  public Mono<Ingredient> updateIngredient(@PathVariable String id, @RequestBody Ingredient ingredient) {
     if (!ingredient.getId().equals(id)) {
       throw new IllegalStateException("Given ingredient's ID doesn't match the ID in the path.");
     }
-    repo.save(ingredient);
+    return repo.save(ingredient);
   }
 
   @PostMapping
@@ -63,8 +63,8 @@ public class IngredientController {
   }
 
   @DeleteMapping("/{id}")
-  public void deleteIngredient(@PathVariable String id) {
-    repo.deleteById(id);
+  public Mono<Void> deleteIngredient(@PathVariable String id) {
+    return repo.deleteById(id);
   }
 
 }


### PR DESCRIPTION
… enable auto-subscription

Make put/delete endpoints return WebFlux reactive types to be used without explicit subscription