### PR TITLE
use batch operation to save order

### DIFF
--- a/ch03/tacos-sd-jpa/pom.xml
+++ b/ch03/tacos-sd-jpa/pom.xml
@@ -80,8 +80,8 @@
     </dependency>
     <!-- end::springDataJpa[] -->
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/ch03/tacos-sd-jpa/src/main/resources/application.properties
+++ b/ch03/tacos-sd-jpa/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.jpa.hibernate.ddl-auto=create
+spring.datasource.url=jdbc:mysql://localhost:3306/tacocloud?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=root
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.show-sql: true

--- a/ch03/tacos-sd-jpa/src/main/resources/application.yml
+++ b/ch03/tacos-sd-jpa/src/main/resources/application.yml
@@ -1,4 +1,0 @@
-spring:
-  datasource:
-    generate-unique-name: false
-    name: tacocloud

--- a/ch04/tacos-sd-cassandra/src/main/java/tacos/web/OrderController.java
+++ b/ch04/tacos-sd-cassandra/src/main/java/tacos/web/OrderController.java
@@ -39,12 +39,12 @@ public class OrderController {
     log.info("Use CassandraBatchOperations to save order.");
     CassandraBatchOperations batch = template.batchOps();
     batch.insert(order);
-    order.getTacos().stream().map(a -> {
+    batch.insert(order.getTacos().stream().map(a -> {
       Taco taco = new Taco();
       taco.setName(a.getName());
       taco.setIngredients(a.getIngredients());
       return taco;
-    }).forEach(batch::insert);
+    }));
     batch.execute();
     sessionStatus.setComplete();
 

--- a/ch04/tacos-sd-mongodb/pom.xml
+++ b/ch04/tacos-sd-mongodb/pom.xml
@@ -94,7 +94,7 @@
     <dependency>
       <groupId>de.flapdoodle.embed</groupId>
       <artifactId>de.flapdoodle.embed.mongo</artifactId>
-      <!-- <scope>test</scope> -->
+      <scope>test</scope>
     </dependency>
     <!-- end::flapDoodle[] -->
   </dependencies>

--- a/ch04/tacos-sd-mongodb/src/main/resources/application.properties
+++ b/ch04/tacos-sd-mongodb/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 logging.level.org.springframework.jdbc.core.JdbcTemplate=debug
+
+spring:
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: tacoclouddb


### PR DESCRIPTION
Before this change, there is no data saved to table tacos when submit an order. 
With this change, the taco info is saved in both table tacos and orders done by batch operations.
Here is what I got in Cassandra database:
```
cqlsh:taco_cloud> select * from tacos;

 id                                   | createdat                | ingredients                                                                | name
--------------------------------------+--------------------------+----------------------------------------------------------------------------+-------------
 0f46c5f0-64c7-11ee-a129-5382fcad8921 | 2023-10-07 04:07:41+0000 | [{name: 'Corn Tortilla', type: 'WRAP'}, {name: 'Cheddar', type: 'CHEESE'}] | lily's taco

(1 rows)
cqlsh:taco_cloud> select id, tacos from orders;

 id                                   | tacos
--------------------------------------+-------------------------------------------------------------------------------------------------------------------
 02b9bae0-64c7-11ee-a129-5382fcad8921 | [{ingredients: [{name: 'Corn Tortilla', type: 'WRAP'}, {name: 'Cheddar', type: 'CHEESE'}], name: 'lily''s taco'}]

(1 rows)
```